### PR TITLE
feat: add command `workflow execute`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@ulisesgascon/string-to-array": "2.0.0",
         "ajv": "8.17.1",
+        "ajv-formats": "3.0.1",
         "commander": "14.0.0",
         "got": "14.4.7",
         "nock": "14.0.5",
@@ -3093,6 +3094,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-escapes": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@ulisesgascon/string-to-array": "2.0.0",
+        "ajv": "8.17.1",
         "commander": "14.0.0",
         "got": "14.4.7",
         "nock": "14.0.5",
@@ -1052,6 +1053,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -1062,6 +1080,13 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.2",
@@ -3055,16 +3080,15 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -4972,6 +4996,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/eslint/node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -4982,6 +5023,13 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eslint/node_modules/minimatch": {
       "version": "3.1.2",
@@ -5200,7 +5248,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -5246,6 +5293,22 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
+      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -8953,10 +9016,9 @@
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -10076,6 +10138,15 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "@ulisesgascon/string-to-array": "2.0.0",
     "ajv": "8.17.1",
+    "ajv-formats": "3.0.1",
     "commander": "14.0.0",
     "got": "14.4.7",
     "nock": "14.0.5",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@ulisesgascon/string-to-array": "2.0.0",
+    "ajv": "8.17.1",
     "commander": "14.0.0",
     "got": "14.4.7",
     "nock": "14.0.5",

--- a/src/__tests__/cli-commands.test.ts
+++ b/src/__tests__/cli-commands.test.ts
@@ -432,6 +432,32 @@ describe('CLI Commands', () => {
       expect(result.messages).toHaveLength(3) // Header + 2 workflow items
     })
 
+    it('should handle disabled workflows', async () => {
+      // Add a second workflow item
+      const secondWorkflow = {
+        ...mockWorkflows[0],
+        id: 'create-stuff',
+        description: 'Another workflow description',
+        isEnabled: false
+      }
+      mockWorkflows.push(secondWorkflow)
+
+      // Mock API call
+      nock('http://localhost:3000')
+        .get('/api/v1/workflow')
+        .reply(200, mockWorkflows)
+
+      // Execute the function
+      const result = await printWorkflows()
+
+      // Verify the result
+      expect(result.success).toBe(true)
+      expect(result.messages[0]).toBe('Compliance workflows available:')
+      expect(result.messages[1]).toContain(mockWorkflows[0].id)
+      expect(result.messages[1]).toContain(mockWorkflows[0].description)
+      expect(result.messages).toHaveLength(2) // Header + 1 enabled workflow item
+    })
+
     it('should handle API errors gracefully', async () => {
       // Mock API error
       nock('http://localhost:3000')

--- a/src/__tests__/cli-commands.test.ts
+++ b/src/__tests__/cli-commands.test.ts
@@ -527,7 +527,7 @@ describe('CLI Commands', () => {
       // Verify the result
       expect(result.success).toBe(true)
       expect(result.messages).toHaveLength(5) // 5 messages with details
-      expect(result.messages[0]).toContain('Workflow executed successfully in 2500 ms')
+      expect(result.messages[0]).toContain('Workflow executed successfully in 2.50 seconds')
       expect(result.messages[1]).toContain('Status: completed')
       expect(result.messages[2]).toContain('Started:')
       expect(result.messages[3]).toContain('Finished:')
@@ -547,7 +547,7 @@ describe('CLI Commands', () => {
       // Verify the result
       expect(result.success).toBe(true)
       expect(result.messages).toHaveLength(5) // 5 messages with details
-      expect(result.messages[0]).toContain('Workflow executed unsuccessfully in 2500 ms')
+      expect(result.messages[0]).toContain('Workflow executed unsuccessfully in 2.50 seconds')
       expect(result.messages[1]).toContain('Status: failed')
       expect(result.messages[2]).toContain('Started:')
       expect(result.messages[3]).toContain('Finished:')

--- a/src/__tests__/fixtures.ts
+++ b/src/__tests__/fixtures.ts
@@ -127,5 +127,6 @@ export const mockAPIWorkflowResponse: APIWorkflowItem[] = [{
   description: 'Test workflow description',
   isEnabled: true,
   isRequiredAdditionalData: false,
-  operations: null
+  operations: null,
+  schema: null
 }]

--- a/src/__tests__/fixtures.ts
+++ b/src/__tests__/fixtures.ts
@@ -1,4 +1,4 @@
-import { APIHealthResponse, APIProjectDetails, APIGithubOrgDetails, APIChecklistItem, APICheckItem, APIWorkflowItem } from '../types.js'
+import { APIHealthResponse, APIProjectDetails, APIGithubOrgDetails, APIChecklistItem, APICheckItem, APIWorkflowItem, APIWorkflowRunItem } from '../types.js'
 
 export const mockApiHealthResponse: APIHealthResponse = {
   status: 'ok',
@@ -130,3 +130,11 @@ export const mockAPIWorkflowResponse: APIWorkflowItem[] = [{
   operations: null,
   schema: null
 }]
+
+export const mockAPIWorkflowRunResponse: APIWorkflowRunItem = {
+  status: 'completed',
+  started: '2025-06-21T10:05:00.000Z',
+  finished: '2025-06-21T10:05:02.500Z',
+  completed: '2025-06-21T10:05:02.500Z',
+  result: { success: true, message: 'Workflow completed successfully' }
+}

--- a/src/__tests__/fixtures.ts
+++ b/src/__tests__/fixtures.ts
@@ -124,5 +124,8 @@ export const mockAPICheckResponse: APICheckItem[] = [{
 
 export const mockAPIWorkflowResponse: APIWorkflowItem[] = [{
   id: 'update-stuff',
-  description: 'Test workflow description'
+  description: 'Test workflow description',
+  isEnabled: true,
+  isRequiredAdditionalData: false,
+  operations: null
 }]

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -1,6 +1,6 @@
 import { getConfig } from './utils.js'
 import { got } from 'got'
-import { APIHealthResponse, APIProjectDetails, APIGithubOrgDetails, APIChecklistItem, APICheckItem, APIWorkflowItem } from './types.js'
+import { APIHealthResponse, APIProjectDetails, APIGithubOrgDetails, APIChecklistItem, APICheckItem, APIWorkflowItem, APIWorkflowRunItem } from './types.js'
 
 export const apiClient = () => {
   const config = getConfig()
@@ -78,4 +78,17 @@ export const getAllWorkflows = async (): Promise<APIWorkflowItem[]> => {
     throw new Error(`Failed to get the data from the API: ${response.statusCode} ${response.body}`)
   }
   return response.body as APIWorkflowItem[]
+}
+
+export const runWorkflow = async (workflowId: string, data: any): Promise<APIWorkflowRunItem> => {
+  const client = apiClient()
+  const payload = data ? { data } : {}
+  const response = await client.post(`workflow/${workflowId}/run`, {
+    json: payload,
+    responseType: 'json'
+  })
+  if (response.statusCode !== 202) {
+    throw new Error(`Failed to run the workflow: ${response.statusCode} ${response.body}`)
+  }
+  return response.body as APIWorkflowRunItem
 }

--- a/src/cli-commands.ts
+++ b/src/cli-commands.ts
@@ -148,8 +148,9 @@ export const executeWorkflow = async (workflowId: string, data: any): Promise<Co
     const startTime = new Date(results.started)
     const endTime = new Date(results.finished)
     const duration = endTime.getTime() - startTime.getTime()
+    const durationStr = duration < 1000 ? `${duration} ms` : `${(duration / 1000).toFixed(2)} seconds`
 
-    messages.push(`Workflow executed ${results.result.success ? 'successfully' : 'unsuccessfully'} in ${duration} ms`)
+    messages.push(`Workflow executed ${results.result.success ? 'successfully' : 'unsuccessfully'} in ${durationStr}`)
     messages.push(`- Status: ${results.status}`)
     messages.push(`- Started: ${startTime}`)
     messages.push(`- Finished: ${endTime}`)

--- a/src/cli-commands.ts
+++ b/src/cli-commands.ts
@@ -125,7 +125,9 @@ export const printWorkflows = async (): Promise<CommandResult> => {
     }
     messages.push('Compliance workflows available:')
     workflows.forEach((workflow) => {
-      messages.push(`- ${workflow.id}: ${workflow.description}`)
+      if (workflow.isEnabled) {
+        messages.push(`- ${workflow.id}: ${workflow.description}`)
+      }
     })
   } catch (error) {
     messages.push(`❌ Failed to retrieve compliance workflow items: ${error instanceof Error ? error.message : 'Unknown error'}`)

--- a/src/cli-commands.ts
+++ b/src/cli-commands.ts
@@ -1,6 +1,6 @@
 import { CommandResult } from './types.js'
 import { isApiAvailable, isApiCompatible, getPackageJson } from './utils.js'
-import { getAPIDetails, createProject, addGithubOrgToProject, getAllChecklistItems, getAllChecks, getAllWorkflows } from './api-client.js'
+import { getAPIDetails, createProject, addGithubOrgToProject, getAllChecklistItems, getAllChecks, getAllWorkflows, runWorkflow } from './api-client.js'
 
 const pkg = getPackageJson()
 
@@ -131,6 +131,31 @@ export const printWorkflows = async (): Promise<CommandResult> => {
     })
   } catch (error) {
     messages.push(`❌ Failed to retrieve compliance workflow items: ${error instanceof Error ? error.message : 'Unknown error'}`)
+    success = false
+  }
+
+  return {
+    messages,
+    success
+  }
+}
+
+export const executeWorkflow = async (workflowId: string, data: any): Promise<CommandResult> => {
+  const messages: string[] = []
+  let success = true
+  try {
+    const results = await runWorkflow(workflowId, data)
+    const startTime = new Date(results.started)
+    const endTime = new Date(results.finished)
+    const duration = endTime.getTime() - startTime.getTime()
+
+    messages.push(`Workflow executed ${results.result.success ? 'successfully' : 'unsuccessfully'} in ${duration} ms`)
+    messages.push(`- Status: ${results.status}`)
+    messages.push(`- Started: ${startTime}`)
+    messages.push(`- Finished: ${endTime}`)
+    messages.push(`- Result: ${results.result.message}`)
+  } catch (error) {
+    messages.push(`❌ Failed to execute the workflow: ${error instanceof Error ? error.message : 'Unknown error'}`)
     success = false
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,13 +56,18 @@ workflow
     }
     // Check if workflow requires additional data and if it is provided or requires collection
     if (workflow.isRequiredAdditionalData && (!options.data && !options.file)) {
-      throw new Error('Workflow does not require additional data. Please remove -d or -f options')
+      throw new Error('Workflow requires additional data. Please provide data using -d or -f option')
     } else if (options.data && options.file) {
       throw new Error('Please provide either -d or -f, not both')
     } else if (options.data) {
       data = options.data
     } else if (options.file) {
-      data = JSON.parse(fs.readFileSync(options.file, 'utf-8'))
+      try {
+        const fileContent = fs.readFileSync(options.file, 'utf-8')
+        data = JSON.parse(fileContent)
+      } catch (error) {
+        throw new Error(`Failed to read or parse file: ${error instanceof Error ? error.message : 'Unknown error'}`)
+      }
     }
 
     // If data is provided, validate against JSON Schema

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,10 @@
 import { Command } from 'commander'
 // @ts-ignore
 import { stringToArray } from '@ulisesgascon/string-to-array'
-import { handleCommandResult } from './utils.js'
-import { getVersion, runDoctor, addProjectWithGithubOrgs, printChecklists, printChecks, printWorkflows } from './cli-commands.js'
+import { handleCommandResult, validateData } from './utils.js'
+import { getAllWorkflows } from './api-client.js'
+import fs from 'fs'
+import { getVersion, runDoctor, addProjectWithGithubOrgs, printChecklists, printChecks, printWorkflows, executeWorkflow } from './cli-commands.js'
 
 const program = new Command()
 
@@ -32,6 +34,50 @@ workflow
   .description('Print all available compliance workflows')
   .action(async () => {
     const result = await printWorkflows()
+    handleCommandResult(result)
+  })
+
+workflow
+  .command('execute')
+  .description('Execute a compliance workflow')
+  .requiredOption('-w, --workflow <workflowName>', 'Workflow name')
+  .option('-d, --data <data>', 'Data to pass to the workflow')
+  .option('-f, --file <file>', 'File containing the data to be parsed')
+  .action(async (options) => {
+    // @TODO: Move to utils and include tests when the backend has one workflow that requires additional data
+    const workflows = await getAllWorkflows()
+    const workflow = workflows.find((workflow) => workflow.id === options.workflow)
+    let data: any | undefined
+    if (!workflow) {
+      throw new Error(`Invalid workflow name (${options.workflow}). Available workflows: ${workflows.map(w => w.id).join(', ')}`)
+    }
+    if (!workflow.isEnabled) {
+      throw new Error('Workflow is not enabled')
+    }
+    // Check if workflow requires additional data and if it is provided or requires collection
+    if (workflow.isRequiredAdditionalData && (!options.data && !options.file)) {
+      throw new Error('Workflow does not require additional data. Please remove -d or -f options')
+    } else if (options.data && options.file) {
+      throw new Error('Please provide either -d or -f, not both')
+    } else if (options.data) {
+      data = options.data
+    } else if (options.file) {
+      data = JSON.parse(fs.readFileSync(options.file, 'utf-8'))
+    }
+
+    // If data is provided, validate against JSON Schema
+    if (data) {
+      const schema = workflow.schema
+      if (!schema) {
+        throw new Error('Workflow does not have a JSON schema')
+      }
+      const result = await validateData(data, schema)
+      if (!result.success) {
+        throw new Error(`Data validation failed: ${result.messages[0]}`)
+      }
+    }
+
+    const result = await executeWorkflow(options.workflow, data)
     handleCommandResult(result)
   })
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -142,11 +142,23 @@ export type APICheckItem = {
 };
 
 /**
+ * Workflow Operation Schema
+ */
+interface WorkflowOperationItem {
+  id: string;
+  description: string;
+  schema: string;
+}
+
+/**
  * Workflow Schema
  */
 export interface APIWorkflowItem {
   id: string;
   description: string;
+  isEnabled: boolean;
+  isRequiredAdditionalData: boolean;
+  operations: WorkflowOperationItem[] | null;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -164,6 +164,17 @@ export interface APIWorkflowItem {
 }
 
 /**
+ * Workflow Run Schema
+ */
+export interface APIWorkflowRunItem {
+  status: string;
+  started: string;
+  finished: string;
+  completed: string;
+  result: { success: boolean; message: string };
+}
+
+/**
  * Error object as defined in the OpenAPI schema
  */
 export interface APIErrorObject {

--- a/src/types.ts
+++ b/src/types.ts
@@ -143,6 +143,7 @@ export type APICheckItem = {
 
 /**
  * Workflow Operation Schema
+ * @TODO: Move or reuse with bulk-import endpoint is created.
  */
 interface WorkflowOperationItem {
   id: string;
@@ -158,6 +159,7 @@ export interface APIWorkflowItem {
   description: string;
   isEnabled: boolean;
   isRequiredAdditionalData: boolean;
+  schema: string | null;
   operations: WorkflowOperationItem[] | null;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,13 @@ import { Config, APIHealthResponse, CommandResult } from './types.js'
 import { readFileSync } from 'fs'
 import { fileURLToPath } from 'url'
 import { dirname, join } from 'path'
+import Ajv from 'ajv'
+import addFormats from 'ajv-formats'
+
+// Use type assertions to bypass TypeScript errors
+// @TODO: Remove type assertions when ajv-formats is updated
+const ajv = new (Ajv as any)()
+;(addFormats as any)(ajv)
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -41,5 +48,20 @@ export const handleCommandResult = (result: CommandResult) => {
   } else {
     console.error(result.messages.join('\n'))
     process.exit(1)
+  }
+}
+
+export const validateData = (data: any, schema: any) => {
+  const validate = ajv.compile(schema)
+  const valid = validate(data)
+  if (!valid) {
+    return {
+      success: false,
+      messages: validate.errors?.map((error: any) => error.message) || []
+    }
+  }
+  return {
+    success: true,
+    messages: []
   }
 }


### PR DESCRIPTION
Related #1 
Related #https://github.com/OpenPathfinder/visionBoard/pull/249 (no merge before this)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to execute compliance workflows via a new CLI subcommand, supporting data input directly or from a file.
  - Workflows can now require and validate additional data against a JSON schema before execution.
  - Only enabled workflows are listed and executable in the CLI.

- **Improvements**
  - Enhanced workflow execution output with detailed status, timing, and result messages.

- **Bug Fixes**
  - Disabled workflows are now excluded from workflow listings.

- **Tests**
  - Added comprehensive tests for workflow execution, including success, failure, and error scenarios.

- **Chores**
  - Added dependencies for JSON schema validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->