### PR TITLE
chore: use to `/api/v1/workflow/:id/execute`

### DIFF
--- a/src/__tests__/cli-commands.test.ts
+++ b/src/__tests__/cli-commands.test.ts
@@ -518,7 +518,7 @@ describe('CLI Commands', () => {
     it('should execute a workflow successfully', async () => {
       // Mock API call
       nock('http://localhost:3000')
-        .post('/api/v1/workflow/update-stuff/run', { data: { projectId: 123 } })
+        .post('/api/v1/workflow/update-stuff/execute', { data: { projectId: 123 } })
         .reply(202, workflowRunResponse)
 
       // Execute the function
@@ -538,7 +538,7 @@ describe('CLI Commands', () => {
     it('Should execute a workflow that was unsuccessful', async () => {
       // Mock API call
       nock('http://localhost:3000')
-        .post('/api/v1/workflow/update-stuff/run', { data: { projectId: 123 } })
+        .post('/api/v1/workflow/update-stuff/execute', { data: { projectId: 123 } })
         .reply(202, { ...workflowRunResponse, status: 'failed', result: { message: 'Failed to execute workflow', success: false } })
 
       // Execute the function
@@ -558,7 +558,7 @@ describe('CLI Commands', () => {
     it('should handle API errors gracefully', async () => {
       // Mock API error
       nock('http://localhost:3000')
-        .post('/api/v1/workflow/invalid-workflow/run')
+        .post('/api/v1/workflow/invalid-workflow/execute')
         .reply(404, { errors: [{ message: 'Workflow not found' }] } as APIErrorResponse)
 
       // Execute the function
@@ -573,7 +573,7 @@ describe('CLI Commands', () => {
     it('should handle network errors gracefully', async () => {
       // Mock network error
       nock('http://localhost:3000')
-        .post('/api/v1/workflow/update-stuff/run')
+        .post('/api/v1/workflow/update-stuff/execute')
         .replyWithError('Network error')
 
       // Execute the function

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -83,7 +83,7 @@ export const getAllWorkflows = async (): Promise<APIWorkflowItem[]> => {
 export const runWorkflow = async (workflowId: string, data: any): Promise<APIWorkflowRunItem> => {
   const client = apiClient()
   const payload = data ? { data } : {}
-  const response = await client.post(`workflow/${workflowId}/run`, {
+  const response = await client.post(`workflow/${workflowId}/execute`, {
     json: payload,
     responseType: 'json'
   })


### PR DESCRIPTION
Related to #1 and https://github.com/OpenPathfinder/visionBoard/pull/250

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the workflow execution endpoint to use the correct API path, ensuring consistent and reliable workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->