### PR TITLE
feat: add command `bulk-import run`

### DIFF
--- a/src/__tests__/fixtures.ts
+++ b/src/__tests__/fixtures.ts
@@ -1,4 +1,4 @@
-import { APIHealthResponse, APIProjectDetails, APIGithubOrgDetails, APIChecklistItem, APICheckItem, APIWorkflowItem, APIWorkflowRunItem, APIBulkImportOperationItem } from '../types.js'
+import { APIHealthResponse, APIProjectDetails, APIGithubOrgDetails, APIChecklistItem, APICheckItem, APIWorkflowItem, APIOperationCompleted, APIBulkImportOperationItem } from '../types.js'
 
 export const mockApiHealthResponse: APIHealthResponse = {
   status: 'ok',
@@ -131,7 +131,7 @@ export const mockAPIWorkflowResponse: APIWorkflowItem[] = [{
   schema: null
 }]
 
-export const mockAPIWorkflowRunResponse: APIWorkflowRunItem = {
+export const mockAPIWorkflowRunResponse: APIOperationCompleted = {
   status: 'completed',
   started: '2025-06-21T10:05:00.000Z',
   finished: '2025-06-21T10:05:02.500Z',
@@ -144,3 +144,11 @@ export const mockAPIBulkImportOperationResponse: APIBulkImportOperationItem[] = 
   description: 'Test bulk import operation description',
   schema: 'test-bulk-import-operation'
 }]
+
+export const mockAPIBulkImportOperationRunResponse: APIOperationCompleted = {
+  status: 'completed',
+  started: '2025-06-21T10:05:00.000Z',
+  finished: '2025-06-21T10:05:02.500Z',
+  completed: '2025-06-21T10:05:02.500Z',
+  result: { success: true, message: 'Bulk import operation completed successfully' }
+}

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -1,6 +1,6 @@
 import { getConfig } from './utils.js'
 import { got } from 'got'
-import { APIHealthResponse, APIProjectDetails, APIGithubOrgDetails, APIChecklistItem, APICheckItem, APIWorkflowItem, APIWorkflowRunItem, APIBulkImportOperationItem } from './types.js'
+import { APIHealthResponse, APIProjectDetails, APIGithubOrgDetails, APIChecklistItem, APICheckItem, APIWorkflowItem, APIOperationCompleted, APIBulkImportOperationItem } from './types.js'
 
 export const apiClient = () => {
   const config = getConfig()
@@ -80,7 +80,7 @@ export const getAllWorkflows = async (): Promise<APIWorkflowItem[]> => {
   return response.body as APIWorkflowItem[]
 }
 
-export const runWorkflow = async (workflowId: string, data: any): Promise<APIWorkflowRunItem> => {
+export const runWorkflow = async (workflowId: string, data: any): Promise<APIOperationCompleted> => {
   const client = apiClient()
   const payload = data ? { data } : {}
   const response = await client.post(`workflow/${workflowId}/execute`, {
@@ -90,7 +90,7 @@ export const runWorkflow = async (workflowId: string, data: any): Promise<APIWor
   if (response.statusCode !== 202) {
     throw new Error(`Failed to run the workflow: ${response.statusCode} ${response.body}`)
   }
-  return response.body as APIWorkflowRunItem
+  return response.body as APIOperationCompleted
 }
 
 export const getAllBulkImportOperations = async (): Promise<APIBulkImportOperationItem[]> => {
@@ -100,4 +100,19 @@ export const getAllBulkImportOperations = async (): Promise<APIBulkImportOperati
     throw new Error(`Failed to get the data from the API: ${response.statusCode} ${response.body}`)
   }
   return response.body as APIBulkImportOperationItem[]
+}
+
+export const runBulkImportOperation = async (id: string, payload: any): Promise<APIOperationCompleted> => {
+  const client = apiClient()
+  const response = await client.post('bulk-import', {
+    json: { id, payload },
+    responseType: 'json',
+    throwHttpErrors: false
+  })
+
+  if (response.statusCode <= 500 && response.statusCode >= 400) {
+    throw new Error(`Failed to run the bulk import operation: ${response.statusCode} ${JSON.stringify(response.body, null, 2)}`)
+  }
+
+  return response.body as APIOperationCompleted
 }

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -110,7 +110,7 @@ export const runBulkImportOperation = async (id: string, payload: any): Promise<
     throwHttpErrors: false
   })
 
-  if (response.statusCode <= 500 && response.statusCode >= 400) {
+  if (response.statusCode < 500 && response.statusCode >= 400) {
     throw new Error(`Failed to run the bulk import operation: ${response.statusCode} ${JSON.stringify(response.body, null, 2)}`)
   }
 

--- a/src/cli-commands.ts
+++ b/src/cli-commands.ts
@@ -1,6 +1,6 @@
 import { CommandResult } from './types.js'
 import { isApiAvailable, isApiCompatible, getPackageJson } from './utils.js'
-import { getAPIDetails, createProject, addGithubOrgToProject, getAllChecklistItems, getAllChecks, getAllWorkflows, getAllBulkImportOperations, runWorkflow } from './api-client.js'
+import { getAPIDetails, createProject, addGithubOrgToProject, getAllChecklistItems, getAllChecks, getAllWorkflows, getAllBulkImportOperations, runWorkflow, runBulkImportOperation } from './api-client.js'
 
 const pkg = getPackageJson()
 
@@ -184,6 +184,32 @@ export const printBulkImportOperations = async (): Promise<CommandResult> => {
     })
   } catch (error) {
     messages.push(`❌ Failed to retrieve bulk import operation items: ${error instanceof Error ? error.message : 'Unknown error'}`)
+    success = false
+  }
+
+  return {
+    messages,
+    success
+  }
+}
+
+export const executeBulkImportOperation = async (id: string, data: any): Promise<CommandResult> => {
+  const messages: string[] = []
+  let success = true
+  try {
+    const results = await runBulkImportOperation(id, data)
+    const startTime = new Date(results.started)
+    const endTime = new Date(results.finished)
+    const duration = endTime.getTime() - startTime.getTime()
+    const durationStr = duration < 1000 ? `${duration} ms` : `${(duration / 1000).toFixed(2)} seconds`
+
+    messages.push(`Bulk import operation executed ${results.result.success ? 'successfully' : 'unsuccessfully'} in ${durationStr}`)
+    messages.push(`- Status: ${results.status}`)
+    messages.push(`- Started: ${startTime}`)
+    messages.push(`- Finished: ${endTime}`)
+    messages.push(`- Result: ${results.result.message}`)
+  } catch (error) {
+    messages.push(`❌ Failed to execute the bulk import operation: ${error instanceof Error ? error.message : 'Unknown error'}`)
     success = false
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,7 +73,7 @@ bulkImport
     }
 
     if (!operation.schema) {
-      throw new Error('Bulk import operation does not have a JSON schema. This is an API error')
+      throw new Error('Bulk import operation does not have a JSON schema for data validation. This is an API error')
     }
 
     // If data is provided, validate against JSON Schema

--- a/src/types.ts
+++ b/src/types.ts
@@ -175,7 +175,7 @@ export interface APIWorkflowItem {
 /**
  * Workflow Run Schema
  */
-export interface APIWorkflowRunItem {
+export interface APIOperationCompleted {
   status: string;
   started: string;
   finished: string;


### PR DESCRIPTION
Related #1 and https://github.com/OpenPathfinder/visionBoard/pull/253

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new CLI subcommand to run bulk import operations, supporting input via direct JSON or file, with validation and detailed result output.

- **Bug Fixes**
	- Improved error handling and user feedback for invalid IDs, missing or conflicting data options, JSON parsing, and schema validation failures.

- **Refactor**
	- Renamed an internal interface for consistency; no impact on user-facing functionality.

- **Tests**
	- Expanded test coverage for bulk import operations, including success, API errors, and network errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->