### PR TITLE
docs: add bash example

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,19 @@ Options for `project add`:
 - `-n, --name <name>`: Project name (required)
 - `-g, --github-orgs <githubOrgUrls...>`: GitHub organization URLs (optional)
 
+## Scripting with visionBoard CLI
+
+The visionBoard CLI can be incorporated into automation scripts for more complex workflows. Below is an example of how to chain multiple operations in a shell script.
+
+The sample script ([sample.sh](sample.sh)) demonstrates how to:
+
+1. Configure the CLI using environment variables
+2. Verify connectivity with the API
+3. List available resources for reference
+4. Set up a new project with GitHub integration
+5. Execute various workflows with and without parameters
+6. Perform bulk imports using both inline JSON and file-based input
+
 ## Configuration
 
 The visionBoard CLI supports configuration through environment variables:

--- a/sample.sh
+++ b/sample.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Set environment variables for configuration
+export VISIONBOARD_INSTANCE_URL=http://localhost:3000
+
+# Step 1: Verify environment and connectivity
+echo "=== Verifying environment and connectivity ==="
+visionboard version
+visionboard doctor
+
+# Step 2: List available resources
+echo "\n=== Listing available resources ==="
+visionboard workflow list
+visionboard compliance-check list
+visionboard compliance-checklist list
+visionboard bulk-import list
+
+# Step 3: Project setup
+echo "\n=== Setting up project ==="
+visionboard project add -n express -g https://github.com/expressjs
+
+# Step 4: Execute workflows
+echo "\n=== Executing workflows ==="
+visionboard workflow execute -w update-github-orgs
+visionboard workflow execute -w run-all-checks
+
+# Step 5: Execute workflow with inline JSON data
+echo "\n=== Executing workflow with inline JSON data ==="
+visionboard workflow execute -w run-one-check -d '{"check_name": "softwareArchitectureDocs"}'
+
+# Step 6: Execute workflow with JSON data from file
+echo "\n=== Executing workflow with JSON data from file ==="
+cat > ./manual-check.json << EOF
+{
+  "check_name": "softwareArchitectureDocs"
+}
+EOF
+visionboard workflow execute -w run-one-check -f ./manual-check.json
+
+# Step 7: Bulk import with inline JSON data
+echo "\n=== Performing bulk import with inline JSON data ==="
+visionboard bulk-import run -i load-manual-checks -d '[
+  { 
+    "type": "annualDependencyRefresh", 
+    "project_id": 1, 
+    "is_subscribed": true 
+  }
+]'
+
+# Step 8: Bulk import with JSON data from file
+echo "\n=== Performing bulk import with JSON data from file ==="
+cat > ./import.json << EOF
+[
+  {
+    "type": "annualDependencyRefresh", 
+    "project_id": 1, 
+    "is_subscribed": true 
+  }
+]
+EOF
+visionboard bulk-import run -i load-manual-checks -f ./import.json
+
+echo "\n=== Script execution completed ==="


### PR DESCRIPTION
Closes #1 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new section to the README with guidance and examples for automating VisionBoard CLI tasks using scripts.
- **New Features**
  - Introduced a sample Bash script demonstrating automated workflows and bulk operations with the VisionBoard CLI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->